### PR TITLE
Release v0.1.13 from worktree

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -284,12 +284,6 @@ if [[ "$is_worktree" == "true" && "$current_branch" != "HEAD" && "$current_branc
   echo "Detected worktree release from branch $current_branch (not $main_branch)"
   echo "Creating PR to merge $current_branch into $main_branch with auto-merge enabled"
   
-  # Verify that the tag will be accessible from main after merge
-  if ! git merge-base --is-ancestor "$(git rev-parse HEAD)" "$main_branch" 2>/dev/null; then
-    echo "⚠️  Warning: Current commit is not an ancestor of $main_branch"
-    echo "   This may cause issues if the PR is not merged as a fast-forward"
-  fi
-  
   # Create PR title and body
   pr_title="Release $tag from worktree"
   pr_body="This PR merges the release $tag from worktree branch \`$current_branch\` into \`$main_branch\`.
@@ -302,7 +296,7 @@ if [[ "$is_worktree" == "true" && "$current_branch" != "HEAD" && "$current_branc
 This PR is set to auto-merge once CI passes."
   
   # Create the PR
-  if gh pr create --title "$pr_title" --body "$pr_body" --base "$main_branch" --head "$current_branch" --label "release" 2>/dev/null; then
+  if gh pr create --title "$pr_title" --body "$pr_body" --base "$main_branch" --head "$current_branch" 2>/dev/null; then
     echo "✅ PR created successfully"
     
     # Enable auto-merge on the PR

--- a/bin/release
+++ b/bin/release
@@ -71,6 +71,7 @@ Behavior:
   - Creates an annotated git tag locally if missing, pushes it to the remote.
   - Creates a GitHub Release for the tag if it does not already exist.
   - Fails if the tag already exists locally or remotely unless --force is provided.
+  - When releasing from a worktree (not main branch), automatically creates a PR with auto-merge enabled.
 
 Examples:
   # Simple release with explicit version
@@ -90,6 +91,9 @@ Examples:
 
   # Provide custom release notes/title
   bin/release patch -m "Bugfixes and improvements"
+
+  # Release from worktree (creates PR with auto-merge)
+  bin/release 1.2.3  # When run from a worktree branch, creates PR to main
 USAGE
 }
 
@@ -195,6 +199,32 @@ if ! git remote get-url "$remote" >/dev/null 2>&1; then
   fi
 fi
 
+# Detect if we're in a worktree and not on main branch
+git_dir=$(git rev-parse --git-dir)
+is_worktree=false
+main_branch="main"
+
+# Check if we're in a worktree
+if [[ "$git_dir" == *"/.git/worktrees/"* ]]; then
+  is_worktree=true
+fi
+
+# Try to detect main branch (check for main, master, or main branch from remote)
+if git show-ref --verify --quiet "refs/heads/main"; then
+  main_branch="main"
+elif git show-ref --verify --quiet "refs/heads/master"; then
+  main_branch="master"
+else
+  # Try to get default branch from remote
+  if command -v git >/dev/null 2>&1; then
+    local default_branch
+    default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')
+    if [[ -n "$default_branch" ]]; then
+      main_branch="$default_branch"
+    fi
+  fi
+fi
+
 # Ensure the current branch is pushed before creating the release/tag
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
 if [[ "$current_branch" != "HEAD" ]]; then
@@ -247,6 +277,52 @@ else
   echo "Creating GitHub Release $tag"
   gh release create "$tag" --title "$tag" --notes "$notes"
   echo "Release $tag created"
+fi
+
+# If we're in a worktree and not on the main branch, create a PR with auto-merge
+if [[ "$is_worktree" == "true" && "$current_branch" != "HEAD" && "$current_branch" != "$main_branch" ]]; then
+  echo "Detected worktree release from branch $current_branch (not $main_branch)"
+  echo "Creating PR to merge $current_branch into $main_branch with auto-merge enabled"
+  
+  # Verify that the tag will be accessible from main after merge
+  if ! git merge-base --is-ancestor "$(git rev-parse HEAD)" "$main_branch" 2>/dev/null; then
+    echo "⚠️  Warning: Current commit is not an ancestor of $main_branch"
+    echo "   This may cause issues if the PR is not merged as a fast-forward"
+  fi
+  
+  # Create PR title and body
+  pr_title="Release $tag from worktree"
+  pr_body="This PR merges the release $tag from worktree branch \`$current_branch\` into \`$main_branch\`.
+
+**Release Details:**
+- Tag: \`$tag\`
+- Release Notes: $notes
+- Created from worktree branch: \`$current_branch\`
+
+This PR is set to auto-merge once CI passes."
+  
+  # Create the PR
+  if gh pr create --title "$pr_title" --body "$pr_body" --base "$main_branch" --head "$current_branch" --label "release" 2>/dev/null; then
+    echo "✅ PR created successfully"
+    
+    # Enable auto-merge on the PR
+    pr_number=$(gh pr list --head "$current_branch" --base "$main_branch" --json number --jq '.[0].number' 2>/dev/null)
+    if [[ -n "$pr_number" && "$pr_number" != "null" ]]; then
+      if gh pr merge "$pr_number" --auto --squash 2>/dev/null; then
+        echo "✅ Auto-merge enabled for PR #$pr_number"
+        echo "🔗 View PR: $(gh pr view "$pr_number" --web --json url --jq '.url' 2>/dev/null)"
+      else
+        echo "⚠️  PR created but auto-merge could not be enabled. You may need to enable it manually."
+        echo "🔗 View PR: $(gh pr view "$pr_number" --web --json url --jq '.url' 2>/dev/null)"
+      fi
+    else
+      echo "⚠️  PR created but could not retrieve PR number for auto-merge setup"
+    fi
+  else
+    echo "❌ Failed to create PR. You may need to create it manually."
+    echo "💡 Suggested command:"
+    echo "   gh pr create --title \"$pr_title\" --body \"$pr_body\" --base \"$main_branch\" --head \"$current_branch\""
+  fi
 fi
 
 echo "Done."


### PR DESCRIPTION
This PR merges the release v0.1.13 from worktree branch `worktrees/ryanwjackson/release-from-worktree` into `main`.

**Release Details:**
- Tag: `v0.1.13`
- Release Notes: v0.1.13
- Created from worktree branch: `worktrees/ryanwjackson/release-from-worktree`

This PR is set to auto-merge once CI passes.