### PR TITLE
Release v0.3.3 from worktree

### DIFF
--- a/bin/gtr
+++ b/bin/gtr
@@ -35,7 +35,7 @@ GTR_VERSION="@VERSION@"
 _gtr_print_version() {
   # If we have a real version (not the placeholder), use it directly
   if [[ -n "$GTR_VERSION" && "$GTR_VERSION" =~ ^v?[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-    echo "gtr version $GTR_VERSION"
+    echo "$GTR_VERSION"
     return
   fi
 
@@ -49,7 +49,7 @@ _gtr_print_version() {
     brew_info=$(brew list --versions gtr 2>/dev/null | head -1)
     if [[ -n "$brew_info" ]]; then
       local brew_version="${brew_info#gtr }"
-      echo "gtr version $brew_version"
+      echo "$brew_version"
       return
     fi
   fi
@@ -61,19 +61,19 @@ _gtr_print_version() {
     if [[ -n "$git_describe" ]]; then
       version_info=" ($git_describe)"
     fi
-    echo "gtr version dev${version_info}"
+    echo "dev${version_info}"
     return
   fi
 
   # Method 3: Try to extract from script path (some package managers include version in path)
   if [[ "$script_dir" =~ /([0-9]+\.[0-9]+(\.[0-9]+)?)/bin$ ]]; then
     local path_version="${BASH_REMATCH[1]}"
-    echo "gtr version $path_version"
+    echo "$path_version"
     return
   fi
 
   # Fallback
-  echo "gtr version unknown"
+  echo "unknown"
 }
 
 # Private helper functions (prefixed with _gtr_)


### PR DESCRIPTION
This PR merges the release v0.3.3 from worktree branch `worktrees/gtr/ryanwjackson/fix-version` into `main`.

**Release Details:**
- Tag: `v0.3.3`
- Release Notes: v0.3.3
- Created from worktree branch: `worktrees/gtr/ryanwjackson/fix-version`

This PR is set to auto-merge once CI passes.