### PR TITLE
Release v0.7.4 from rj/ci2

### DIFF
--- a/.github/workflows/bump-homebrew.yml
+++ b/.github/workflows/bump-homebrew.yml
@@ -96,27 +96,12 @@ jobs:
             fi
           fi
 
-      - name: Check release requirements for automerge
+      - name: Skip if no release tag found
         if: steps.check_release.outputs.should_run != 'true'
         run: |
-          echo "No release tag found in this commit."
-          
-          # Check if this is a dry run
-          DRY="${{ github.event.inputs.dry_run || 'false' }}"
-          
-          if [[ "$DRY" == "true" ]]; then
-            echo "Dry run enabled. Skipping Homebrew bump (no release required)."
-            echo "To trigger a release, include a version tag (e.g., v1.2.3) in your commit message or push a release tag."
-            exit 0
-          else
-            echo "ERROR: Automerge is enabled but no release tag found on the last commit."
-            echo "This prevents automatic merging of PRs without proper releases."
-            echo "To fix this:"
-            echo "1. Include a version tag (e.g., v1.2.3) in your commit message, OR"
-            echo "2. Push a release tag with this commit, OR"
-            echo "3. Use workflow_dispatch with dry_run=true to skip this check"
-            exit 1
-          fi
+          echo "No release tag found in this commit. Skipping Homebrew bump."
+          echo "To trigger a release, include a version tag (e.g., v1.2.3) in your commit message or push a release tag."
+          exit 0
 
       - name: Ensure GH CLI is authenticated
         env:

--- a/.github/workflows/release-tag-check.yml
+++ b/.github/workflows/release-tag-check.yml
@@ -17,54 +17,33 @@ jobs:
         # Fetch all history and tags to properly check for release tags
         fetch-depth: 0
 
-    - name: Check for release tag in PR (informational only)
+    - name: Check for release tag on PR head
       run: |
         # Get the head commit of the PR
         head_commit=$(git rev-parse HEAD)
         echo "PR head commit: $head_commit"
-        
-        # Get the base commit (target branch)
-        base_commit="${{ github.event.pull_request.base.sha }}"
-        echo "PR base commit: $base_commit"
-        
+
         # Check if there's a release tag pointing to the head commit
-        head_release_tags=$(git tag -l 'v*.*.*' --points-at "$head_commit" || true)
-        
-        # If no tag on head, check for tags in the PR's commit range
-        if [[ -z "$head_release_tags" ]]; then
-          echo "No release tag found on HEAD commit, checking PR commit range..."
-          
-          # Get all commits in the PR (from base to head)
-          pr_commits=$(git rev-list "$base_commit..$head_commit" || true)
-          
-          if [[ -n "$pr_commits" ]]; then
-            echo "Checking for release tags in PR commits:"
-            for commit in $pr_commits; do
-              commit_tags=$(git tag -l 'v*.*.*' --points-at "$commit" || true)
-              if [[ -n "$commit_tags" ]]; then
-                echo "✅ Found release tag(s) on commit $commit:"
-                echo "$commit_tags"
-                head_release_tags="$commit_tags"
-                break
-              fi
-            done
-          fi
-        fi
-        
-        if [[ -z "$head_release_tags" ]]; then
-          echo "ℹ️  No release tag found in this PR."
+        release_tags=$(git tag -l 'v*.*.*' --points-at "$head_commit" || true)
+
+        if [[ -z "$release_tags" ]]; then
+          echo "❌ No release tag found on the latest commit of this PR."
           echo ""
-          echo "This is informational only. Release tags are not required for development PRs."
-          echo "When ready to release, use the bin/release script to create a proper release."
+          echo "This PR cannot be merged into main without a release tag on the latest commit."
+          echo "To fix this:"
+          echo "1. Create a release tag on the latest commit: git tag v1.2.3"
+          echo "2. Push the tag: git push origin v1.2.3"
+          echo "3. Or use the bin/release script to create a proper release"
           echo ""
           echo "Available tags on recent commits:"
           git log --oneline --decorate -10 || true
+          exit 1
         else
-          echo "✅ Found release tag(s) in this PR:"
-          echo "$head_release_tags"
-          
+          echo "✅ Found release tag(s) on the latest commit:"
+          echo "$release_tags"
+
           # Validate that it's a proper semantic version tag
-          for tag in $head_release_tags; do
+          for tag in $release_tags; do
             if [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               echo "✅ Valid semantic version tag: $tag"
             else
@@ -90,25 +69,8 @@ jobs:
     - name: Verify release tag integrity
       run: |
         head_commit=$(git rev-parse HEAD)
-        base_commit="${{ github.event.pull_request.base.sha }}"
-        
-        # Find release tags in the PR (same logic as the main check)
         release_tags=$(git tag -l 'v*.*.*' --points-at "$head_commit" || true)
-        
-        if [[ -z "$release_tags" ]]; then
-          # Check for tags in the PR's commit range
-          pr_commits=$(git rev-list "$base_commit..$head_commit" || true)
-          if [[ -n "$pr_commits" ]]; then
-            for commit in $pr_commits; do
-              commit_tags=$(git tag -l 'v*.*.*' --points-at "$commit" || true)
-              if [[ -n "$commit_tags" ]]; then
-                release_tags="$commit_tags"
-                break
-              fi
-            done
-          fi
-        fi
-        
+
         if [[ -n "$release_tags" ]]; then
           for tag in $release_tags; do
             # Check if tag exists on remote
@@ -117,7 +79,7 @@ jobs:
             else
               echo "⚠️  Tag $tag exists locally but not on remote - this may cause issues"
             fi
-            
+
             # Check if it's an annotated tag (preferred for releases)
             if git cat-file -t "$tag" | grep -q "tag"; then
               echo "✅ Tag $tag is an annotated tag (preferred for releases)"
@@ -125,6 +87,4 @@ jobs:
               echo "ℹ️  Tag $tag is a lightweight tag (annotated tags are preferred for releases)"
             fi
           done
-        else
-          echo "ℹ️  No release tags found to verify"
         fi


### PR DESCRIPTION
This PR merges the release v0.7.4 from branch `rj/ci2` into `main`.

**Release Details:**
- Tag: `v0.7.4`
- Release Notes: v0.7.4
- Created from branch: `rj/ci2`

This PR is set to auto-merge once CI passes.